### PR TITLE
added :to Keyword to read-message

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [clojure-mail "0.1.3-SNAPSHOT"]
 ```
 
-A clojure library mainly aimed at parsing, downloading and reading email from Gmail servers.
+A clojure library mainly aimed at parsing, downloading and reading email from Gmail servers (it works for private domains as well).
 
 Possible uses for this library include machine learning corpus generation and command line mail clients.
 
@@ -28,7 +28,8 @@ Quick example of how to read a message from your inbox
 
 ;; Returns the first message from my gmail account
 
-{:from "EuroDNS Customer Services <support@eurodns.com>",
+{:to ("you+someAlias@gmail.com" "you+anotherAlias@gmail.com" "someone@gmail.com"),
+ :from "EuroDNS Customer Services <support@eurodns.com>",
  :subject "Re: Domain",
  :sender "EuroDNS Customer Services <support@eurodns.com>",
  :date-sent "Thu Apr 04 20:33:42 BST 2013",

--- a/src/clojure_mail/message.clj
+++ b/src/clojure_mail/message.clj
@@ -12,6 +12,11 @@
     "text/plain" :plain
     (str "unexpected type, \"" type \")))
 
+(defn to 
+  "Returns a sequence of receivers"
+  [m]
+    (map str (.getRecipients m javax.mail.Message$RecipientType/TO)))
+
 (defn from [m]
   (.toString
     (.getFrom m)))
@@ -114,7 +119,8 @@
    This is the ultimate goal in extracting a message
    as a clojure map"
   (try
-    {:from (sender msg)
+    {:to (to msg)
+     :from (sender msg)
      :subject (subject msg)
      :sender (sender msg)
      :date-sent (date-sent msg)


### PR DESCRIPTION
Hi, first of all thanks for sharing this useful repo :+1: . I just added a handy `:to` keyword to `read-message` returned map. I missed it as I work with gmail aliases. 

Cheers
