### PR TITLE
Added details about setting authentication ref via auth! method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The first thing we need to do is create a mail store that acts as a gateway to y
 Alternativley some methods make use of authentication settings held in a `ref` to avoid having to pass the mail store around.  The ref can be set like so,
 
 ```clojure
-(mail/auth! "USER@GMAIL.COM" "PASSWORD")
+(auth! "USER@GMAIL.COM" "PASSWORD")
 ```
 
 Now we can get 5 messages from our inbox


### PR DESCRIPTION
I've been using this library a bit today and initially butted up against the issue that the details in the README were insufficient to actually understand and use the examples correctly.  The biggest issue was that various examples in the README didn't make use of your defined `store` method and instead used the 0 arg version of `gen-store` internally which requires using `auth!` initially.

I have added a tiny bit to the README to highlight this.
