### PR TITLE
More docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ HTML emails are evil. There is a simple HTML -> Plain text parser provided if yo
 do any machine learning type processing on email messages.
 
 ```clojure
+(require '[clojure-mail.parser :refer :all])
+
 (html->text "<h1>I HATE HTML EMAILS</h1>")
 
 ;; => "I HATE HTML EMAILS"


### PR DESCRIPTION
Just some quick notes that I took while getting up to speed with the new version.

Related:
I can call 

``` clojure
(org.jsoup.Jsoup/parse "foo" "UTF-8")
```

just fine in a REPL in the project, but I get

``` clojure
(html->text (:body (first (inbox 1)) ))

IllegalArgumentException No matching method found: parse  clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:80)
```

when trying to use `html->text`. Any clues as to how I can get around this / fix this? Thanks in advance!
