### PR TITLE
Search for messages where query matches subject *or* body, not *and*

### DIFF
--- a/src/clojure_mail/folder.clj
+++ b/src/clojure_mail/folder.clj
@@ -1,5 +1,5 @@
 (ns clojure-mail.folder
-  (:import [javax.mail.search SearchTerm AndTerm SubjectTerm BodyTerm]))
+  (:import [javax.mail.search SearchTerm OrTerm SubjectTerm BodyTerm]))
 
 ;; note that the get folder fn is part of the store namespace
 
@@ -42,7 +42,7 @@
   (.getMessages folder))
 
 (defn search [f query]
-  (let [search-term (AndTerm. (SubjectTerm. query) (BodyTerm. query))]
+  (let [search-term (OrTerm. (SubjectTerm. query) (BodyTerm. query))]
     (.search f search-term)))
 
 (defn list [f]


### PR DESCRIPTION
Hi,
I noticed that the search function searches for messages where the query string is contained both in the message's subject and body. This isn't what I'd expect from a simple search feature, it certainly surprised me. Looking at the code led to the assumption that the intent probably is to search for messages where the query string is contained in subject _or_ body.

If I'm right about the actual intent of the function, replacing AndTerm by OrTerm would fix it.
