### PR TITLE
Add missing store parameter, and remove warning.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-mail "0.1.6"
+(defproject clojure-mail "0.1.7-SNAPSHOT"
   :description "Clojure Email Library"
   :url "https://github.com/forward/clojure-mail"
   :license {:name "Eclipse Public License"

--- a/src/clojure_mail/core.clj
+++ b/src/clojure_mail/core.clj
@@ -142,7 +142,7 @@
   "Returns the number of messages in a folder"
   ([folder-name] (message-count *store* folder-name))
   ([store folder-name]
-     (let [folder (open-folder folder-name :readonly)]
+     (let [folder (open-folder store folder-name :readonly)]
        (.getMessageCount folder))))
 
 (defn user-flags [message]
@@ -153,7 +153,7 @@
   "Find unread messages"
   ([folder-name] (unread-messages *store* folder-name))
   ([^com.sun.mail.imap.IMAPStore store folder-name]
-     (let [folder (open-folder folder-name :readonly)]
+     (let [folder (open-folder store folder-name :readonly)]
        (.search folder
          (FlagTerm. (Flags. Flags$Flag/SEEN) false)))))
 
@@ -161,7 +161,7 @@
   "Mark all messages in folder as read"
   ([folder-name] (mark-all-read *store* folder-name))
   ([^com.sun.mail.imap.IMAPStore store folder-name]
-     (let [folder (open-folder folder-name :readwrite)
+     (let [folder (open-folder store folder-name :readwrite)
            messages (.search folder (FlagTerm. (Flags. Flags$Flag/SEEN) false))]
        (doall (map #(.setFlags % (Flags. Flags$Flag/SEEN) true) messages))
        nil)))

--- a/src/clojure_mail/folder.clj
+++ b/src/clojure_mail/folder.clj
@@ -1,4 +1,5 @@
 (ns clojure-mail.folder
+  (:refer-clojure :exclude [list])
   (:import [javax.mail.search SearchTerm OrTerm SubjectTerm BodyTerm]))
 
 ;; note that the get folder fn is part of the store namespace


### PR DESCRIPTION
Some functions were not passing through the store parameter, but
accidentally relying on the thread-bound _store_ instead.

Also, removed warning for replacing "list" from clojure.core. It turns
out that doing this actually causes a NPE when compiling (eg: lein
uberjar) a project that depends on clojure-mail.
