### PR TITLE
Let user handle connection errors

### DIFF
--- a/src/clojure_mail/core.clj
+++ b/src/clojure_mail/core.clj
@@ -63,18 +63,12 @@
   ([protocol server email pass]
    (let [p (as-properties
             {"mail.store.protocol"                         protocol
-             (format "mail.%s.usesocketchannels" protocol) true})]
-     (try
-       (doto (.getStore (Session/getDefaultInstance p) protocol)
-         (.connect server email pass))
-       (catch AuthenticationFailedException e
-         (format "Invalid credentials %s : %s" email pass)))))
+             (format "mail.%s.usesocketchannels" protocol) true})
+         session (Session/getDefaultInstance p)]
+     (store protocol session server email pass)))
   ([protocol session server email pass]
-   (try
-     (doto (.getStore session protocol)
-       (.connect server email pass))
-     (catch AuthenticationFailedException e
-       (format "Invalid credentials %s : %s" email pass)))))
+   (doto (.getStore session protocol)
+     (.connect server email pass))))
 
 (defn connected?
   "Returns true if a connection is established"

--- a/src/clojure_mail/message.clj
+++ b/src/clojure_mail/message.clj
@@ -41,7 +41,7 @@
 
 (defn from
   [m]
-  (imap-address->map (.getFrom m)))
+  (map imap-address->map (.getFrom m)))
 
 (defn subject
   "Fetch the subject of a mail message"
@@ -51,7 +51,9 @@
 (defn sender
   "Extract the message sender"
   [^MimeMessage msg]
-  (imap-address->map (.getSender msg)))
+  (let [address (.getSender msg)]
+    (when address
+      (imap-address->map address))))
 
 ;; Dates
 ;; *********************************************************


### PR DESCRIPTION
For https://github.com/owainlewis/clojure-mail/issues/28

I also saw that errors while reading a message won't be recorded, `nil` is returned for each field and there will be no overall `Exception`. I thought it's better to make sure all errors are recorded in an `:errors` field whilst still populating all the fields possible.