### PR TITLE
add fetch-messages function to pre-fetch a sequence of messages

### DIFF
--- a/src/clojure_mail/folder.clj
+++ b/src/clojure_mail/folder.clj
@@ -1,7 +1,7 @@
 (ns clojure-mail.folder
   (:refer-clojure :exclude [list])
   (:import [javax.mail.search SearchTerm OrTerm SubjectTerm BodyTerm]
-           (com.sun.mail.imap IMAPFolder IMAPFolder$FetchProfileItem)
+           (com.sun.mail.imap IMAPFolder IMAPFolder$FetchProfileItem IMAPMessage)
            (javax.mail FetchProfile)))
 
 ;; note that the get folder fn is part of the store namespace
@@ -64,7 +64,7 @@
                :content-info IMAPFolder$FetchProfileItem/CONTENT_INFO
                :size IMAPFolder$FetchProfileItem/SIZE)
         _ (.add fp item)]
-    (.fetch f ms fp)))
+    (.fetch f (into-array IMAPMessage ms) fp)))
 
 (defn get-messages
   "Gets all messages from folder f or get the Message objects for message numbers ranging from start through end,


### PR DESCRIPTION
I wanted to read an entire folder in one go but by default each message (and seemingly each field) is read individually, this PR makes things much much faster when you want to deal with lots of messages.