### PR TITLE
port parameter for store function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ pom.xml
 .lein-plugins
 .DS_Store
 .nrepl-port
+*.iml
+.idea/
+.lein-repl-history

--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,5 @@
                  [org.jsoup/jsoup "1.8.3"] ;; for cleaning up messy html messages
                  [com.sun.mail/javax.mail "1.5.4"]
                  [medley "0.7.0"]]
-  :plugins [[lein-cljfmt "0.3.0"]])
+  :plugins [[lein-cljfmt "0.3.0"]]
+  :profiles {:dev {:dependencies [[com.icegreen/greenmail "1.4.1"]]}})

--- a/src/clojure_mail/core.clj
+++ b/src/clojure_mail/core.clj
@@ -8,9 +8,9 @@
            [java.io FileInputStream File]
            [javax.mail.internet MimeMessage]
            [javax.mail Session
-            Folder
-            Flags
-            Flags$Flag AuthenticationFailedException]
+                       Folder
+                       Flags
+                       Flags$Flag AuthenticationFailedException]
            (com.sun.mail.imap IMAPStore)))
 
 (defonce ^:dynamic *store* nil)
@@ -51,24 +51,48 @@
 (defn get-session
   [protocol]
   (let [p (as-properties
-           {"mail.store.protocol"                         protocol
-            (format "mail.%s.usesocketchannels" protocol) true})]
+            {"mail.store.protocol"                         protocol
+             (format "mail.%s.usesocketchannels" protocol) true})]
     (Session/getInstance p)))
+
+(defn server->host-port
+  "Given a protocol (`\"imap\"` or `\"imaps\"`) and a `server` that can be
+
+   * a `String` with the hostname
+   * a `vector` of the form `[hostname, port]`
+
+   It returns a vector `[host, port]` using the `protocol` well-known
+   ports if required."
+  [protocol server]
+  (let [default-port (case (keyword protocol) :imap 143 :imaps 943)]
+    (if (sequential? server)
+      (do
+        (when (empty? server)
+          (throw (IllegalArgumentException. "Empty sequential server")))
+        (if (> (count server) 1)
+          (vec (take 2 server))
+          [(first server) default-port]))
+      [server default-port])))
 
 (defn store
   "A store models a message store and its access protocol,
-   for storing and retrieving messages"
+   for storing and retrieving messages.
+   The `server` parameter can be a String with the hostname or
+   a vector like [^String hostname ^int port]. The first form will
+   make the connection use the default ports for the defined
+   `protocol`."
   ([server email pass]
    (store "imaps" server email pass))
   ([protocol server email pass]
    (let [p (as-properties
-            {"mail.store.protocol"                         protocol
-             (format "mail.%s.usesocketchannels" protocol) true})
-         session (Session/getDefaultInstance p)]
+             {"mail.store.protocol"                         protocol
+              (format "mail.%s.usesocketchannels" protocol) true})
+         session (Session/getInstance p)]
      (store protocol session server email pass)))
   ([protocol session server email pass]
-   (doto (.getStore session protocol)
-     (.connect server email pass))))
+   (let [[target-host target-port] (server->host-port protocol server)]
+     (doto (.getStore session protocol)
+       (.connect ^String target-host ^int target-port ^String email ^String pass)))))
 
 (defn connected?
   "Returns true if a connection is established"
@@ -97,7 +121,7 @@
   "Check if a folder is a sub folder"
   (fn [folder]
     (if (= 0 (bit-and
-              (.getType folder) Folder/HOLDS_FOLDERS))
+               (.getType folder) Folder/HOLDS_FOLDERS))
       false
       true)))
 
@@ -106,10 +130,10 @@
   ([store] (folders store (.getDefaultFolder store)))
   ([store f]
    (map
-    #(cons (.getName %)
-           (if (sub-folder? %)
-             (folders store %)))
-    (.list f))))
+     #(cons (.getName %)
+            (if (sub-folder? %)
+              (folders store %)))
+     (.list f))))
 
 (def folder-permissions
   {:readonly  Folder/READ_ONLY
@@ -159,14 +183,14 @@
                (drop 1 (message/id message)))]
     (.writeTo message
               (java.io.FileOutputStream.
-               filename))))
+                filename))))
 
 (defn dump
   "Handy function that dumps out a batch of emails to disk"
   [msgs]
   (let [message-futures
         (doall
-         (map #(future (save-message-to-file %)) msgs))]
+          (map #(future (save-message-to-file %)) msgs))]
     (map deref message-futures)))
 
 ;; Public API

--- a/test/clojure_mail/core_test.clj
+++ b/test/clojure_mail/core_test.clj
@@ -1,3 +1,23 @@
 (ns clojure-mail.core-test
   (:require [clojure.test :refer :all]
             [clojure-mail.core :refer :all]))
+
+(deftest server->host-port-test
+  (testing "non sequential server returns default ports"
+    (are [protocol server port] (= [server port] (server->host-port protocol server))
+                                "imap" "localhost" 143
+                                "imaps" "localhost" 943
+                                :imap "localhost" 143
+                                :imaps "localhost" 943))
+  (testing "sequential, one element server returns default ports"
+    (are [protocol server port] (= [server port] (server->host-port protocol [server]))
+                                "imap" "localhost" 143
+                                "imaps" "localhost" 943
+                                :imap "localhost" 143
+                                :imaps "localhost" 943))
+  (testing "sequential, two element server returns non-default ports"
+    (are [protocol server port] (= [server port] (server->host-port protocol [server port]))
+                                "imap" "localhost" 1234
+                                "imaps" "localhost" 1234
+                                :imap "localhost" 1234
+                                :imaps "localhost" 1234)))

--- a/test/clojure_mail/imap_integration.clj
+++ b/test/clojure_mail/imap_integration.clj
@@ -1,0 +1,73 @@
+(ns clojure-mail.imap-integration
+  (:require [clojure.test :refer :all]
+            [clojure-mail.core :refer :all]
+            [clojure-mail.message :as message])
+  (:import [com.icegreen.greenmail.util GreenMail ServerSetupTest]
+           [javax.mail Session Message$RecipientType]
+           [javax.mail.internet InternetAddress MimeMessage]))
+
+(def ^:dynamic *the-gm*)
+(def ^:dynamic *user1*)
+(def ^:dynamic *user2*)
+
+(defn setup-gm
+  "Global fixture which sets up GreenMail"
+  [f]
+  (binding [*the-gm* (GreenMail. ServerSetupTest/IMAP)]
+    (f)
+    (.stop *the-gm*)))
+
+(defn reset-gm
+  [f]
+  (.reset *the-gm*)
+  (binding [*user1* (.setUser *the-gm* "user1@localhost" "user1" "password1")
+            *user2* (.setUser *the-gm* "user2@localhost" "user2" "password2")]
+    (f)))
+
+(defn get-service-port
+  "gets the port GreenMail is listening on for the specific service.
+  service-type should be either :imap or :imaps."
+  [service-type]
+  (case service-type
+    :imap (..  *the-gm* (getImap) (getPort))
+    :imaps (.. *the-gm* (getImaps) (getPort))))
+
+(defn create-direct-text-message
+  "Creates a text message to be delivered
+  directly to a GreenMail user without using an MTA"
+  [from to subject body]
+  (let [sess (Session/getInstance (as-properties {"mail.host" "localhost"})) ; This should not have lateral effects
+        msg (doto (MimeMessage. sess)
+              (.setFrom (InternetAddress. from))
+              (.setRecipient Message$RecipientType/TO (InternetAddress. to))
+              (.setSubject subject)
+              (.setContent body, "text/plain"))]
+    msg))
+
+(use-fixtures :once setup-gm)
+(use-fixtures :each reset-gm)
+
+(deftest single-store-test
+  (testing "A single store identifies itself as connected."
+    (let [port (get-service-port :imap)
+          test-store (store "imap" ["localhost" port] "user1" "password1")]
+      (is (connected? test-store)))))
+
+(deftest multiple-connection-test
+  (testing "Multiple stores running at the same time identify themselves as connected."
+    (let [port (get-service-port :imap)
+          test-store-1 (store "imap" ["localhost" port] "user1" "password1")
+          test-store-2 (store "imap" ["localhost" port] "user2" "password2")]
+      (is (and (connected? test-store-1) (connected? test-store-2))))))
+
+(deftest single-email-retrieval
+  (testing "We can retrieve an existing message for a user with a single e-mail in its inbox."
+    (let [msg-subject "User1 to User2"
+          msg (create-direct-text-message "user2@localhost" "user1@localhost" msg-subject "random text.")
+          _ (.deliver *user1* msg)
+          port (get-service-port :imap)
+          test-store-1 (store "imap" ["localhost" port] "user1" "password1")
+          all-msgs (all-messages test-store-1 "inbox")
+          test-subject (message/subject (first all-msgs))] ; inbox folder is case insensitive
+      (is (= 1 (count all-msgs)) "One e-mail in the INBOX folder.")
+      (is (= test-subject msg-subject) "Retrieved subject is equal to delivered subject."))))


### PR DESCRIPTION
As per the issue #33, store now supports the target port to be
passed as a parameter.
Also greenmail has been added as a dependency and some
integration testing has been added.