### PR TITLE
Add Xoauth2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ The first thing we need is a mail store which acts as a gateway to our IMAP acco
 (def store (store "imap.gmail.com" "user@gmail.com" "password"))
 ```
 
+You can also authenticate using an Oauth token.
+
+```clojure
+(def store (xoauth2-store "imap.gmail.com" "user@gmail.com" "user-oauth-token"))
+```
+
 Now we can fetch email messages easily.
 
 ```clojure

--- a/src/clojure_mail/core.clj
+++ b/src/clojure_mail/core.clj
@@ -108,7 +108,8 @@
              (format "mail.%s.auth.mechanisms" protocol) "XOAUTH2"
              (format "mail.%s.usesocketchannels" protocol) true})
          session (Session/getInstance p)]
-     (store protocol session server email oauth-token))))
+     (doto (.getStore session protocol)
+       (.connect server, email, oauth-token)))))
 
 (defn connected?
   "Returns true if a connection is established"

--- a/src/clojure_mail/core.clj
+++ b/src/clojure_mail/core.clj
@@ -98,8 +98,7 @@
 
 (defn xoauth2-store
   ([server email oauth-token]
-   (xoauth2-store "imaps" server email oauth-token)
-   )
+   (xoauth2-store "imaps" server email oauth-token))
   ([protocol server email oauth-token]
    (let [p (as-properties
             {(format "mail.%s.ssl.enable" protocol) true
@@ -109,8 +108,7 @@
              (format "mail.%s.auth.mechanisms" protocol) "XOAUTH2"
              (format "mail.%s.usesocketchannels" protocol) true})
          session (Session/getInstance p)]
-     (store protocol session server email oauth-token)
-     )))
+     (store protocol session server email oauth-token))))
 
 (defn connected?
   "Returns true if a connection is established"

--- a/src/clojure_mail/gmail.clj
+++ b/src/clojure_mail/gmail.clj
@@ -12,7 +12,7 @@
 
 (defn xoauth-store
   ([email oauth-access-token]
-   (mail/store "imaps" "imap.gmail.com"
+   (mail/xoauth2-store "imaps" "imap.gmail.com" email oauth-access-token)))
 
 (def gmail-folders
   {:inbox "INBOX"

--- a/src/clojure_mail/gmail.clj
+++ b/src/clojure_mail/gmail.clj
@@ -10,6 +10,10 @@
   ([session email password]
    (mail/store "imaps" session "imap.gmail.com" email password)))
 
+(defn xoauth-store
+  ([email oauth-access-token]
+   (mail/store "imaps" "imap.gmail.com"
+
 (def gmail-folders
   {:inbox "INBOX"
    :all   "[Gmail]/All Mail"


### PR DESCRIPTION
This change adds a `xoauth2-store` helper function that allows a user to authenticate using an email address and an Oauth access token.

It also adds a Gmail-specific helper in the `clojure-mail/gmail` namespace that sets the Gmail IMAP server and protocol defaults.

The README has been updated with an example of usage.