### PR TITLE
Add :subject key back into read-message map

### DIFF
--- a/src/clojure_mail/message.clj
+++ b/src/clojure_mail/message.clj
@@ -180,6 +180,7 @@
                     :bcc bcc
                     :from from
                     :sender sender
+                    :subject subject
                     :date-sent date-sent
                     :date-received date-received
                     :multipart? multipart?


### PR DESCRIPTION
Since commit 420267c1d4aef063c2e1c89728199ad9cdc7fcb3, it looks like the `:subject` key has been missing from the maps returned by `read-message`. This patch restores the missing field.