### PR TITLE
folder search query syntax is extended

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /checkouts
 pom.xml
 *.jar
+*.swp
 *.class
 .lein-deps-sum
 .lein-failures

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ You can easily search your inbox for messages
 ```clojure
 (def s (gen-store "user@gmail.com" "password"))
 (def results (search-inbox s "projects"))
+(def results (search-inbox s :body "projects" :received-before :yesterday))
+(def results (search-inbox s :body "projects" :from "john@example.com"))
 
 (->> results first subject) ;; => "Open Source Customisation Projects"
 ```

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ You can easily search your inbox for messages
 ```clojure
 (def s (gen-store "user@gmail.com" "password"))
 (def results (search-inbox s "projects"))
+(def results (search-inbox s [:body "projects" :subject "projects"]))
 (def results (search-inbox s :body "projects" :received-before :yesterday))
 (def results (search-inbox s :body "projects" :from "john@example.com"))
 

--- a/test/clojure_mail/search_test.clj
+++ b/test/clojure_mail/search_test.clj
@@ -59,6 +59,19 @@
       (is (= (.getPattern (first (.getTerms q))) "foo"))
       (is (= (type (second (.getTerms q))) javax.mail.search.ReceivedDateTerm))))
 
+  (testing "multiple criteria, vec is or-red"
+    (let [q (folder/search search-stub [:body "foo" :received-on :today])]
+      (is (= (type q) javax.mail.search.OrTerm))
+      (is (= (.getPattern (first (.getTerms q))) "foo"))
+      (is (= (type (second (.getTerms q))) javax.mail.search.ReceivedDateTerm))))
+
+  (testing "header support"
+    (let [q (folder/search search-stub :header "name" "value")]
+      (is (= (type q) javax.mail.search.HeaderTerm)))
+    (let [q (folder/search search-stub :header ["name1" "value1" "name2" "value2"])]
+      (is (= (type q) javax.mail.search.OrTerm))
+      (is (= (type (first (.getTerms q))) javax.mail.search.HeaderTerm))))
+
   (testing "flag support"
     (let [q (folder/search search-stub :answered?)]
       (is (= (.getTestSet q) true))

--- a/test/clojure_mail/search_test.clj
+++ b/test/clojure_mail/search_test.clj
@@ -12,10 +12,17 @@
       (is (= (type (second (.getTerms q))) javax.mail.search.BodyTerm))))
 
   (doall (map #(testing (str "message part condition " %)
-    (let [st (folder/build-search-terms % "query")]
+    (let [st (folder/build-search-terms (list % "query"))]
       (is (= (.getPattern st) "query")))) [:body :subject :from]))
 
   (doall (map #(testing (str "message part condition " %)
-    (let [st (folder/build-search-terms % "foo@example.com")]
+    (let [st (folder/build-search-terms (list % "foo@example.com"))]
       (is (= (.getRecipientType st) (folder/to-recipient-type %))) 
-      (is (= (.getPattern st) "foo@example.com")))) [:to :cc :bcc])))
+      (is (= (.getPattern st) "foo@example.com")))) [:to :cc :bcc]))
+
+  (testing "search value can be an array which is or-red"
+    (let [q (folder/search (reify FolderSearch (search [this st] st)) :body ["foo" "bar"])]
+      (is (= (type q) javax.mail.search.OrTerm))
+      (is (= (.getPattern (first (.getTerms q))) "foo"))
+      (is (= (.getPattern (second (.getTerms q))) "bar")))))
+

--- a/test/clojure_mail/search_test.clj
+++ b/test/clojure_mail/search_test.clj
@@ -1,0 +1,21 @@
+(ns clojure-mail.search-test
+  (:require [clojure.test :refer :all]
+            [clojure-mail.folder :as folder] :reload))
+
+(defprotocol FolderSearch (search [this ^javax.mail.search.SearchTerm st]))
+
+(deftest search-terms
+  (testing "default: string parameter searches within body and subject"
+    (let [q (folder/search (reify FolderSearch (search [this st] st)) "query")]
+      (is (= (.getPattern (first (.getTerms q))) "query"))
+      (is (= (.getPattern (second (.getTerms q))) "query"))
+      (is (= (type (second (.getTerms q))) javax.mail.search.BodyTerm))))
+
+  (doall (map #(testing (str "message part condition " %)
+    (let [st (folder/build-search-terms % "query")]
+      (is (= (.getPattern st) "query")))) [:body :subject :from]))
+
+  (doall (map #(testing (str "message part condition " %)
+    (let [st (folder/build-search-terms % "foo@example.com")]
+      (is (= (.getRecipientType st) (folder/to-recipient-type %))) 
+      (is (= (.getPattern st) "foo@example.com")))) [:to :cc :bcc])))

--- a/test/clojure_mail/search_test.clj
+++ b/test/clojure_mail/search_test.clj
@@ -53,6 +53,12 @@
          (.add d java.util.Calendar/DAY_OF_WEEK -1)
          (is (= (h-day-of-week (.getDate q)) (.get d java.util.Calendar/DAY_OF_WEEK)))))
 
+  (testing "multiple criteria"
+    (let [q (folder/search search-stub :body "foo" :received-on :today)]
+      (is (= (type q) javax.mail.search.AndTerm))
+      (is (= (.getPattern (first (.getTerms q))) "foo"))
+      (is (= (type (second (.getTerms q))) javax.mail.search.ReceivedDateTerm))))
+
   (testing "flag support"
     (let [q (folder/search search-stub :answered?)]
       (is (= (.getTestSet q) true))

--- a/test/clojure_mail/search_test.clj
+++ b/test/clojure_mail/search_test.clj
@@ -3,10 +3,17 @@
             [clojure-mail.folder :as folder] :reload))
 
 (defprotocol FolderSearch (search [this ^javax.mail.search.SearchTerm st]))
+(def search-stub (reify FolderSearch (search [this st] st)))
+
+(defn h-day-of-week
+  [dt]
+  (let [c (java.util.Calendar/getInstance)]
+    (.setTime c dt)
+    (.get c java.util.Calendar/DAY_OF_WEEK)))
 
 (deftest search-terms
   (testing "default: string parameter searches within body and subject"
-    (let [q (folder/search (reify FolderSearch (search [this st] st)) "query")]
+    (let [q (folder/search search-stub "query")]
       (is (= (.getPattern (first (.getTerms q))) "query"))
       (is (= (.getPattern (second (.getTerms q))) "query"))
       (is (= (type (second (.getTerms q))) javax.mail.search.BodyTerm))))
@@ -21,16 +28,36 @@
       (is (= (.getPattern st) "foo@example.com")))) [:to :cc :bcc]))
 
   (testing "search value can be an array which is or-red"
-    (let [q (folder/search (reify FolderSearch (search [this st] st)) :body ["foo" "bar"])]
+    (let [q (folder/search search-stub :body ["foo" "bar"])]
       (is (= (type q) javax.mail.search.OrTerm))
       (is (= (.getPattern (first (.getTerms q))) "foo"))
       (is (= (.getPattern (second (.getTerms q))) "bar"))))
 
+  (testing "date support"
+    (doall (map 
+      #(let [q (folder/search search-stub :sent-before %)]
+         (is (= (type q) javax.mail.search.SentDateTerm))
+         (is (= (.. q (getDate) (getYear)) 116)) ; since 1900
+         (is (= (.getComparison q) javax.mail.search.ComparisonTerm/LE)))
+      ["2016.01.01" "2016-01-01" "2016-01-01 12:00:00" "2016.01.01 12:00"]))
+
+    (doall (map 
+      #(let [q (folder/search search-stub :received-on %)]
+         (is (= (type q) javax.mail.search.ReceivedDateTerm))
+         (is (= (h-day-of-week (.getDate q)) (.get (java.util.Calendar/getInstance) java.util.Calendar/DAY_OF_WEEK))) 
+         (is (= (.getComparison q) javax.mail.search.ComparisonTerm/EQ)))
+      [:today])) 
+
+    (let [q (folder/search search-stub :received-on :yesterday)
+          d (java.util.Calendar/getInstance)]
+         (.add d java.util.Calendar/DAY_OF_WEEK -1)
+         (is (= (h-day-of-week (.getDate q)) (.get d java.util.Calendar/DAY_OF_WEEK)))))
+
   (testing "flag support"
-    (let [q (folder/search (reify FolderSearch (search [this st] st)) :answered?)]
+    (let [q (folder/search search-stub :answered?)]
       (is (= (.getTestSet q) true))
       (is (= (type q) javax.mail.search.FlagTerm)))
-    (let [q (folder/search (reify FolderSearch (search [this st] st)) :-answered?)]
+    (let [q (folder/search search-stub :-seen?)]
       (is (= (.getTestSet q) false)))))
 
 

--- a/test/clojure_mail/search_test.clj
+++ b/test/clojure_mail/search_test.clj
@@ -24,5 +24,15 @@
     (let [q (folder/search (reify FolderSearch (search [this st] st)) :body ["foo" "bar"])]
       (is (= (type q) javax.mail.search.OrTerm))
       (is (= (.getPattern (first (.getTerms q))) "foo"))
-      (is (= (.getPattern (second (.getTerms q))) "bar")))))
+      (is (= (.getPattern (second (.getTerms q))) "bar"))))
+
+  (testing "flag support"
+    (let [q (folder/search (reify FolderSearch (search [this st] st)) :answered?)]
+      (is (= (.getTestSet q) true))
+      (is (= (type q) javax.mail.search.FlagTerm)))
+    (let [q (folder/search (reify FolderSearch (search [this st] st)) :-answered?)]
+      (is (= (.getTestSet q) false)))))
+
+
+
 


### PR DESCRIPTION
Hi Owain,

I have added some extra feature to folder search so it supports much reacher semantics.
Some examples:
- (search f :body "foo" :from joe@example.com") ; searches for msgs with body containing foo received from joe (AND).
- (search f [:body "foo" :subject "foo") ; searches for msgs with body or subject containing foo (original semantics) (array is OR)
- (search f :body ["foo" "bar") ; searches for msgs with body containing foo or bar (value is OR too)
I hope the logic is clear...
Other options are in the source.
I added a search_test.clj and tested manually with gmail imap too. It works I think.

cheers,
joe