### PR TITLE
Bumped javax.mail dependency to 1.5.5 and clojure-mail version to 1.0.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject io.forward/clojure-mail "1.0.5"
+(defproject io.forward/clojure-mail "1.0.6"
   :description "Clojure Email Library"
   :url "https://github.com/forward/clojure-mail"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.jsoup/jsoup "1.8.3"] ;; for cleaning up messy html messages
-                 [com.sun.mail/javax.mail "1.5.4"]
+                 [com.sun.mail/javax.mail "1.5.5"]
                  [medley "0.7.0"]]
   :plugins [[lein-cljfmt "0.3.0"]]
   :profiles {:dev {:dependencies [[com.icegreen/greenmail "1.4.1"]]}})


### PR DESCRIPTION
Updated project.clj as a fix to [issue #54](https://github.com/owainlewis/clojure-mail/issues/54). It looks like `javax.mail 1.5.6` was released in August 2016, so I would be happy to do another PR if you were interested / wanted a couple new releases for `javax` compatibility.