### PR TITLE
Add ability to mark a single message as read

### DIFF
--- a/src/clojure_mail/core.clj
+++ b/src/clojure_mail/core.clj
@@ -184,7 +184,7 @@
   "Find unread messages"
   ([folder-name] (unread-messages *store* folder-name))
   ([^IMAPStore store folder-name]
-   (let [folder (open-folder store folder-name :readonly)]
+   (let [folder (open-folder store folder-name :readwrite)]
      (.search folder
               (FlagTerm. (Flags. Flags$Flag/SEEN) false)))))
 

--- a/src/clojure_mail/message.clj
+++ b/src/clojure_mail/message.clj
@@ -1,7 +1,7 @@
 (ns clojure-mail.message
   (:require [medley.core :refer [filter-keys]])
   (:import [javax.mail.internet InternetAddress MimeMultipart MimeMessage]
-           [javax.mail Message$RecipientType]))
+           [javax.mail Message$RecipientType Flags Flags$Flag]))
 
 (defn mime-type
   "Determine the function to call to get the body text of a message"
@@ -188,3 +188,8 @@
               (filter-keys (set fields) fields-map)
               fields-map)]
     (reduce-kv (partial add-field msg) {} kvs)))
+
+(defn mark-read
+  "Set SEEN flag on a message"
+  [msg]
+  (.setFlags msg (Flags. Flags$Flag/SEEN) true))


### PR DESCRIPTION
It is sometimes desirable to be able to mark a single message as read.