### PR TITLE
Bumped medley 1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,6 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.jsoup/jsoup "1.8.3"] ;; for cleaning up messy html messages
                  [com.sun.mail/javax.mail "1.5.5"]
-                 [medley "0.7.0"]]
+                 [medley "1.0.0"]]
   :plugins [[lein-cljfmt "0.3.0"]]
   :profiles {:dev {:dependencies [[com.icegreen/greenmail "1.4.1"]]}})


### PR DESCRIPTION
Updated meley to 1.0 to get rid of these warnings:

"WARNING: boolean? already refers to: #'clojure.core/boolean? in
namespace: medley.core, being replaced by: #'medley.core/boolean?"

Verified compability and tests are passing ok.