### PR TITLE
Close FileInputStream in file->message

### DIFF
--- a/src/clojure_mail/core.clj
+++ b/src/clojure_mail/core.clj
@@ -41,11 +41,9 @@
    be used to read saved messages from text files
    and for parsing fixtures in tests etc"
   [path-to-message]
-  (let [props (Session/getDefaultInstance (Properties.))
-        ;; removed File since FileInputStream is able
-        ;; to work from File or String (path)
-        msg (FileInputStream. path-to-message)]
-    (MimeMessage. props msg)))
+  (let [props (Session/getDefaultInstance (Properties.))]
+    (with-open [msg (FileInputStream. path-to-message)]
+      (MimeMessage. props msg))))
 
 (defn get-session
   [protocol]


### PR DESCRIPTION
`with-open` makes sure that the `FileInputStream` gets closed after the message is read.

(This can be a problem when reading many messages in a single JVM, you can exhaust available file descriptors.)