### PR TITLE
Bump version / I want the Medley upgrade

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.forward/clojure-mail "1.0.6"
+(defproject io.forward/clojure-mail "1.0.8"
   :description "Clojure Email Library"
   :url "https://github.com/forward/clojure-mail"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
There seems to be some confusion about the current version. When I pull `io.forward/clojure-mail "1.0.7"` into my project, I do not get the very fine commit 5940a091906b571406f19396fdb93d96dcecde52 fixing the `WARNING: boolean? already refers to [...]`.

This PR bumps not one but two minor versions and makes current master `1.0.8`.