### PR TITLE
Add several missing flags to allow deletion, drafting, etc

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,11 @@
   :url "https://github.com/forward/clojure-mail"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.jsoup/jsoup "1.8.3"] ;; for cleaning up messy html messages
-                 [com.sun.mail/javax.mail "1.5.5"]
-                 [medley "1.0.0"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.jsoup/jsoup "1.13.1"] ;; for cleaning up messy html messages
+                 [com.sun.mail/jakarta.mail "1.6.5"]
+                 [medley "1.3.0"]]
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :creds :gpg}]]
   :plugins [[lein-cljfmt "0.3.0"]]
-  :profiles {:dev {:dependencies [[com.icegreen/greenmail "1.4.1"]]}})
+  :profiles {:dev {:dependencies [[com.icegreen/greenmail "1.6.1"]]}})

--- a/src/clojure_mail/folder.clj
+++ b/src/clojure_mail/folder.clj
@@ -1,10 +1,10 @@
 (ns clojure-mail.folder
   (:refer-clojure :exclude [list])
-  (:import [javax.mail.search SearchTerm OrTerm AndTerm SubjectTerm HeaderTerm BodyTerm RecipientStringTerm FromStringTerm FlagTerm ReceivedDateTerm SentDateTerm]
+  (:import [javax.mail.search SearchTerm OrTerm AndTerm SubjectTerm HeaderTerm BodyTerm RecipientStringTerm FromStringTerm FlagTerm ReceivedDateTerm SentDateTerm ComparisonTerm]
            (com.sun.mail.imap IMAPFolder IMAPFolder$FetchProfileItem IMAPMessage)
            (java.text SimpleDateFormat)
            (java.util Calendar)
-           (javax.mail FetchProfile FetchProfile$Item Flags)))
+           (javax.mail FetchProfile FetchProfile$Item Flags Flags$Flag Message$RecipientType)))
 
 ;; Note that the get folder fn is part of the store namespace
 
@@ -83,28 +83,28 @@
   "Converts keyword to recipient type"
   [rt]
   (case rt
-    :to javax.mail.Message$RecipientType/TO
-    :cc javax.mail.Message$RecipientType/CC
-    :bcc javax.mail.Message$RecipientType/BCC))
+    :to Message$RecipientType/TO
+    :cc Message$RecipientType/CC
+    :bcc Message$RecipientType/BCC))
 
 (defn to-flag
   "Converts a string to message flag"
   [fl]
   (case fl
-    (:-answered? :answered?) javax.mail.Flags$Flag/ANSWERED
-    (:-deleted? :deleted?) javax.mail.Flags$Flag/DELETED
-    (:-flagged? :flagged?) javax.mail.Flags$Flag/FLAGGED
-    (:-draft? :draft?) javax.mail.Flags$Flag/DRAFT
-    (:-recent? :recent?) javax.mail.Flags$Flag/RECENT
-    (:-seen? :seen?) javax.mail.Flags$Flag/SEEN))
+    (:-answered? :answered?) Flags$Flag/ANSWERED
+    (:-deleted? :deleted?) Flags$Flag/DELETED
+    (:-flagged? :flagged?) Flags$Flag/FLAGGED
+    (:-draft? :draft?) Flags$Flag/DRAFT
+    (:-recent? :recent?) Flags$Flag/RECENT
+    (:-seen? :seen?) Flags$Flag/SEEN))
 
 (defn to-date-comparison
   "Returns the correct comparison term for search"
   [dt]
-  (cond 
-    (.contains (str dt) "-before") javax.mail.search.ComparisonTerm/LE
-    (.contains (str dt) "-after") javax.mail.search.ComparisonTerm/GE
-    (.contains (str dt) "-on") javax.mail.search.ComparisonTerm/EQ))
+  (cond
+    (.contains (str dt) "-before") ComparisonTerm/LE
+    (.contains (str dt) "-after") ComparisonTerm/GE
+    (.contains (str dt) "-on") ComparisonTerm/EQ))
 
 (def date-formats ["yyyy-MM-dd" "yyyy.MM.dd"])
 

--- a/src/clojure_mail/message.clj
+++ b/src/clojure_mail/message.clj
@@ -91,6 +91,18 @@
   [message]
   (has-flag? message "ANSWERED"))
 
+(defn deleted?
+  [message]
+  (has-flag? message "DELETED"))
+
+(defn draft?
+  [message]
+  (has-flag? message "DRAFT"))
+
+(defn flagged?
+  [message]
+  (has-flag? message "FLAGGED"))
+
 (defn recent?
   [message]
   (has-flag? message "RECENT"))
@@ -191,7 +203,37 @@
               fields-map)]
     (reduce-kv (partial add-field msg) {} kvs)))
 
+(defn- set-flag
+  "Sets a flag on a message"
+  [msg flag]
+  (.setFlags msg flag true))
+
 (defn mark-read
   "Set SEEN flag on a message"
   [msg]
-  (.setFlags msg (Flags. Flags$Flag/SEEN) true))
+  (set-flag msg (Flags. Flags$Flag/SEEN)))
+
+(defn mark-deleted
+  "Set DELETED flag on a message"
+  [msg]
+  (set-flag msg (Flags. Flags$Flag/DELETED)))
+
+(defn mark-answered
+  "Set ANSWERED flag on a message"
+  [msg]
+  (set-flag msg (Flags. Flags$Flag/ANSWERED)))
+
+(defn mark-flagged
+  "Set FLAGGED flag on a message"
+  [msg]
+  (set-flag msg (Flags. Flags$Flag/FLAGGED)))
+
+(defn mark-as-flagged
+  "Set DRAFT flag on a message"
+  [msg]
+  (set-flag msg (Flags. Flags$Flag/DRAFT)))
+
+(defn mark-recent
+  "Set RECENT flag on a message"
+  [msg]
+  (set-flag msg (Flags. Flags$Flag/RECENT)))

--- a/src/clojure_mail/parser.clj
+++ b/src/clojure_mail/parser.clj
@@ -1,7 +1,7 @@
 (ns clojure-mail.parser
   (:import [org.jsoup.nodes Document Element]))
 
-(defn parse [html]
+(defn parse [^String html]
   (org.jsoup.Jsoup/parse html "UTF-8"))
 
 (defn html->text

--- a/test/clojure_mail/helpers/greenmail.clj
+++ b/test/clojure_mail/helpers/greenmail.clj
@@ -32,7 +32,7 @@
   (let [gm (case server
              :imap (GreenMail. ServerSetupTest/IMAP)
              :imaps (GreenMail. ServerSetupTest/IMAPS)
-             :all-imap (GreenMail. [ServerSetupTest/IMAP ServerSetupTest/IMAPS]))]
+             :all-imap (GreenMail.))]
     (if start
       (start-greenmail! gm)
       gm)))


### PR DESCRIPTION
Hi there,

I need to mark messages on a server as "DELETED", so I went ahead and added the respective functions. I haven't been able to add unit tests for the flags since GreenMail doesn't seem to support flags (or at least the messages opened with `load-fixture` don't seem to). If you need me to change anything, let me know.