### PR TITLE
Increase version number

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.forward/clojure-mail "1.0.8"
+(defproject io.forward/clojure-mail "1.0.10"
   :description "Clojure Email Library"
   :url "https://github.com/forward/clojure-mail"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Commit b477e70 introduced a few functions in message.clj. Without the version number
increase, one is unable to access those via clojars.